### PR TITLE
Parabola prm

### DIFF
--- a/include/hpp/rbprm/fullbodyBallistic/ballistic-interpolation.hh
+++ b/include/hpp/rbprm/fullbodyBallistic/ballistic-interpolation.hh
@@ -110,6 +110,15 @@ namespace hpp {
       core::Configuration_t flexionPose () {
 	return flexionPose_;
       }
+      
+      void contactPose (const core::Configuration_t contactPose) {
+	contactPose_ = contactPose;
+      }
+
+      core::Configuration_t contactPose () {
+	return contactPose_;
+      }
+      
 
       const core::PathVectorConstPtr_t path_;
       const State start_;
@@ -210,6 +219,7 @@ namespace hpp {
       BallisticInterpolationWkPtr_t weakPtr_;
       core::Configuration_t extendingPose_;
       core::Configuration_t flexionPose_;
+      core::Configuration_t contactPose_;
     }; // class BallisticInterpolation
   } // namespace rbprm
 } // namespace hpp

--- a/include/hpp/rbprm/fullbodyBallistic/ballistic-interpolation.hh
+++ b/include/hpp/rbprm/fullbodyBallistic/ballistic-interpolation.hh
@@ -233,6 +233,10 @@ namespace hpp {
       core::Configuration_t flexionPose_;
       core::Configuration_t contactPose_;
     }; // class BallisticInterpolation
+    
+    core::Configuration_t computeContactPose(const State &state, core::Configuration_t contactPose,rbprm::RbPrmFullBodyPtr_t robot); 
+
+    
   } // namespace rbprm
 } // namespace hpp
 

--- a/include/hpp/rbprm/fullbodyBallistic/ballistic-interpolation.hh
+++ b/include/hpp/rbprm/fullbodyBallistic/ballistic-interpolation.hh
@@ -207,6 +207,18 @@ namespace hpp {
       core::Configuration_t computeTopExtendingPose 
 	(const core::PathPtr_t path, const BallisticPathPtr_t bp);
 
+      
+      /**
+       * @brief computeContactPose compute the configuration of a waypoint. In contact with the environnement.
+       * Must be called after COmputeContact for the given State.
+       * It return the configuration of the state exept for the trunk DOF and the limb which aren't in contact
+       * @param state 
+       * @return the configuration
+       */
+      core::Configuration_t computeContactPose(const State &state); 
+
+
+      
       /// Blend the two configurations with a as ratio:
       /// result = r*q1 + (1-r)*q2
       core::Configuration_t blendPoses (const core::Configuration_t q1,

--- a/src/fullbodyBallistic/ballistic-interpolation.cc
+++ b/src/fullbodyBallistic/ballistic-interpolation.cc
@@ -320,21 +320,24 @@ namespace hpp {
     
     Configuration_t BallisticInterpolation::computeContactPose(const State& state){
       Configuration_t q = state.configuration_;
-
+      hppDout(info, "contact configuration = "<<displayConfig(contactPose_));
       size_t minIndex = robot_->device_->configSize();
       // replace the limbs not used for contact with their configuration in flexionPose_
       for( rbprm::T_Limb::const_iterator lit = robot_->GetLimbs().begin();lit != robot_->GetLimbs().end(); ++lit){
-        hppDout(notice,"Contact Pose, LIST OF LIMBS  : "<< lit->first << "contact = "<<state.contacts_.at(lit->first));
+        hppDout(notice,"Contact Pose, LIST OF LIMBS  : "<< lit->first << "contact = "<<(state.contacts_.find(lit->first) != state.contacts_.end()));
         if(lit->second->limb_->rankInConfiguration() < minIndex){
-          minIndex =lit->second->limb_->rankInConfiguration();
+          hppDout(notice," Min index = "<<lit->second->limb_->rankInConfiguration()) ;         
+          minIndex = lit->second->limb_->rankInConfiguration();
         }
-        if( !state.contacts_.at(lit->first)){ // limb is not in contact
+        if( (state.contacts_.find(lit->first) != state.contacts_.end())){ // limb is not in contact
           hppDout(notice," Not in contact, index config : "<<lit->second->limb_->rankInConfiguration()<<" -> "<<lit->second->effector_->rankInConfiguration());
           for(size_t i = lit->second->limb_->rankInConfiguration() ; i < lit->second->effector_->rankInConfiguration() ; i++){
             q[i] = contactPose_[i];
           }
         } 
       }
+      
+     
       
       // replace the trunkDOF with contactPose value : (we suppose we always work with freeflyer as root ....)
       for (size_t i = 7 ; i < minIndex ; i++){

--- a/src/fullbodyBallistic/ballistic-interpolation.cc
+++ b/src/fullbodyBallistic/ballistic-interpolation.cc
@@ -318,32 +318,40 @@ namespace hpp {
     }
     
     
-    Configuration_t BallisticInterpolation::computeContactPose(const State& state){
+    Configuration_t computeContactPose(const State& state, Configuration_t contactPose, rbprm::RbPrmFullBodyPtr_t robot){
       Configuration_t q = state.configuration_;
-      hppDout(info, "contact configuration = "<<displayConfig(contactPose_));
-      size_t minIndex = robot_->device_->configSize();
+      bool useAllLimb = true;
+      hppDout(info, "contact configuration = "<<displayConfig(contactPose));
+      size_t minIndex = robot->device_->configSize();
       // replace the limbs not used for contact with their configuration in flexionPose_
-      for( rbprm::T_Limb::const_iterator lit = robot_->GetLimbs().begin();lit != robot_->GetLimbs().end(); ++lit){
+      for( rbprm::T_Limb::const_iterator lit = robot->GetLimbs().begin();lit != robot->GetLimbs().end(); ++lit){
         hppDout(notice,"Contact Pose, LIST OF LIMBS  : "<< lit->first << "contact = "<<(state.contacts_.find(lit->first) != state.contacts_.end()));
         if(lit->second->limb_->rankInConfiguration() < minIndex){
           hppDout(notice," Min index = "<<lit->second->limb_->rankInConfiguration()) ;         
           minIndex = lit->second->limb_->rankInConfiguration();
         }
-        if( (state.contacts_.find(lit->first) != state.contacts_.end())){ // limb is not in contact
+        if( (state.contacts_.find(lit->first) == state.contacts_.end())){ // limb is not in contact
+          useAllLimb = false;
           hppDout(notice," Not in contact, index config : "<<lit->second->limb_->rankInConfiguration()<<" -> "<<lit->second->effector_->rankInConfiguration());
           for(size_t i = lit->second->limb_->rankInConfiguration() ; i < lit->second->effector_->rankInConfiguration() ; i++){
-            q[i] = contactPose_[i];
+            q[i] = contactPose[i];
           }
         } 
       }
       
      
       
-      // replace the trunkDOF with contactPose value : (we suppose we always work with freeflyer as root ....)
-      for (size_t i = 7 ; i < minIndex ; i++){
-        q[i] = contactPose_[i];
+      // replace the trunkDOF with contactPose value : ( 7 because we suppose we always work with freeflyer as root ....)
+      if(!useAllLimb){
+        for (size_t i = 7 ; i < minIndex ; i++){
+          q[i] = contactPose[i];
+        }
       }
       return q;
+    }
+    
+    Configuration_t BallisticInterpolation::computeContactPose(const State& state){
+      rbprm::computeContactPose(state,contactPose_,robot_);
     }
 
     Configuration_t BallisticInterpolation::blendPoses 

--- a/src/fullbodyBallistic/ballistic-interpolation.cc
+++ b/src/fullbodyBallistic/ballistic-interpolation.cc
@@ -237,13 +237,13 @@ namespace hpp {
         if(contactMaintained){
           q_contact_offset = state.configuration_;
           contact_OK = true;
+          lastState = state;
         }else{
           contact_OK = false;
         }
         hppDout (info, "q_contact_offset= " << displayConfig (q_contact_offset));
         hppDout (info, "## contactMaintained = " << contactMaintained);
         
-        lastState = state;
         currentLenght += u;
       }//while
       
@@ -251,6 +251,17 @@ namespace hpp {
       // take limb-configs from contact if contact succeeded, 
       // from interp otherwise.
       //result = replaceLimbConfigsInFullConfig (q_interp,                                               q_contact_offset, fixedLimbs);
+      
+      // replace the limbs not used for contact with their configuration in flexionPose_
+        for( rbprm::T_Limb::const_iterator lit = robot_->GetLimbs().begin();lit != robot_->GetLimbs().end(); ++lit){
+        hppDout(notice,"LIST OF LIMBS : "<< lit->first << "contact = "<<lastState.contacts_[lit->first]);
+        if( ! lastState.contacts_[lit->first]){ // limb is not in contact
+          hppDout(notice," Not in contact, index config : "<<lit->second->limb_->rankInConfiguration()<<" -> "<<lit->second->effector_->rankInConfiguration());
+          for(size_t i = lit->second->limb_->rankInConfiguration() ; i < lit->second->effector_->rankInConfiguration() ; i++){
+            q_contact_offset[i] = flexionPose_[i];
+          }
+        } 
+      }
       return q_contact_offset;
     }
 

--- a/src/fullbodyBallistic/ballistic-planner.cc
+++ b/src/fullbodyBallistic/ballistic-planner.cc
@@ -428,12 +428,16 @@ namespace hpp {
     }
     hppDout(info,"number of contacts : "<<result.numContacts());
     polytope::vector3_t normal;
-    for(size_t k=0 ; k < result.numContacts() ; k++){
+   /* for(size_t k=0 ; k < result.numContacts() ; k++){
       normal = -result.getContact(k).normal; // of contact surface
      // hppDout(info,"normal =  : "<<normal);
       for (std::size_t i = 0; i < 3; i++) {
           normalAv [i] += normal [i]/result.numContacts();
       }
+    }*/
+    normal = -result.getContact(0).normal; // of contact surface    
+    for (std::size_t i = 0; i < 3; i++) {
+        normalAv [i] += normal [i]/nbNormalAv;
     }
   } // for each ROMS
   normalAv.normalize ();

--- a/src/rbprm-fullbody.cc
+++ b/src/rbprm-fullbody.cc
@@ -270,7 +270,7 @@ namespace hpp {
             if(proj->apply(config))
             {
                 hpp::core::ValidationReportPtr_t valRep (new hpp::core::CollisionValidationReport);
-                if(/*limbValidations.at(name)->validate(config, valRep)*/ true)
+                if(/*limbValidations.at(name)->validate(config, valRep) */true)
                 {
                     // stable?
                     current.contacts_[name] = true;

--- a/src/rbprm-fullbody.cc
+++ b/src/rbprm-fullbody.cc
@@ -270,7 +270,7 @@ namespace hpp {
             if(proj->apply(config))
             {
                 hpp::core::ValidationReportPtr_t valRep (new hpp::core::CollisionValidationReport);
-                if(/*limbValidations.at(name)->validate(config, valRep) */true)
+                if(limbValidations.at(name)->validate(config, valRep) /*true*/)
                 {
                     // stable?
                     current.contacts_[name] = true;
@@ -432,7 +432,7 @@ namespace hpp {
     watch.start("collision");
     #endif*/
                 hpp::core::ValidationReportPtr_t valRep (new hpp::core::CollisionValidationReport);
-                if(true) //validation->validate(configuration, valRep))
+                if(validation->validate(configuration, valRep)) // true
                 {
 		  hppDout (info, "config is valid");
 		  /*#ifdef PROFILE

--- a/src/rbprm-shooter.cc
+++ b/src/rbprm-shooter.cc
@@ -198,7 +198,7 @@ namespace
         srand (seed);
         hppDout(notice,"&&&&&& SEED = "<<seed);
 */
-      srand (0);
+     // srand (0);
 
         RbPrmShooter* ptr = new RbPrmShooter (robot, geometries, filter, normalFilters, shootLimit, displacementLimit, nbFilterMatch);
         RbPrmShooterPtr_t shPtr (ptr);

--- a/src/sampling/heuristic.cc
+++ b/src/sampling/heuristic.cc
@@ -78,7 +78,7 @@ double StaticHeuristic(const sampling::Sample& sample,
 HeuristicFactory::HeuristicFactory()
 {
     //srand ( (unsigned int) (time(NULL)) );
-    //srand(0);
+    srand(0);
     heuristics_.insert(std::make_pair("static", &StaticHeuristic));
     heuristics_.insert(std::make_pair("EFORT", &EFORTHeuristic));
     heuristics_.insert(std::make_pair("EFORT_Normal", &EFORTNormalHeuristic));

--- a/src/sampling/heuristic.cc
+++ b/src/sampling/heuristic.cc
@@ -78,7 +78,7 @@ double StaticHeuristic(const sampling::Sample& sample,
 HeuristicFactory::HeuristicFactory()
 {
     //srand ( (unsigned int) (time(NULL)) );
-    srand(0);
+    //srand(0);
     heuristics_.insert(std::make_pair("static", &StaticHeuristic));
     heuristics_.insert(std::make_pair("EFORT", &EFORTHeuristic));
     heuristics_.insert(std::make_pair("EFORT_Normal", &EFORTNormalHeuristic));

--- a/src/sampling/sample-db.cc
+++ b/src/sampling/sample-db.cc
@@ -260,7 +260,6 @@ bool rbprm::sampling::GetCandidates(const SampleDB& sc, const fcl::Transform3f& 
                 normal.normalize();
                 Eigen::Vector3d eNormal(normal[0], normal[1], normal[2]);
 
-                hppDout(notice,"TEST HERE : "<<sit->configuration_);
                 OctreeReport report(&(*sit), contact, evaluate ? ((evaluate)(*sit, eDir, eNormal)) :0, normal);
                 ++okay;
                 reports.insert(report);


### PR DESCRIPTION
Changes in use of reference positions : 

For the contact configuration (the waypoint of the path) we use the heurstic with the distance to the reference position for the limb which can produce contact. For the other limbs and the DOF of the trunk we use contactPose_.

For the last contacting configuration before takeoff we use the maintainPrevious contact until we can't project the constraint. For the limbs which aren't in contact and the DOF of the trunk we use flexionPose_ configuration.

TODO : add random noise to the static configuration ???
